### PR TITLE
Remove threejs dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@
 
 ## Requirements:
 - [nin](http://www.github.com/ninjadev/nin) (Our demotool)
-- [Threejs](http://threejs.org)
 
 ## Setup:
 In nin all your projects are folders. Have this repo as a folder in nin along side `dasBoot`. Rename this folder to `test-project` and you are set.


### PR DESCRIPTION
Nin supplies threejs, so threejs does not need explicit mentioning.
